### PR TITLE
Fix VIC frequency timing to eliminate OBS frame drops

### DIFF
--- a/src/c64u-protocol.h
+++ b/src/c64u-protocol.h
@@ -26,8 +26,8 @@
 // Frame assembly constants
 #define C64U_MAX_PACKETS_PER_FRAME 68           // PAL: 272 lines ÷ 4 lines/packet = 68 packets
 #define C64U_FRAME_TIMEOUT_MS 100               // Timeout for incomplete frames
-#define C64U_PAL_FRAME_INTERVAL_NS 20000000ULL  // 20ms for 50Hz PAL
-#define C64U_NTSC_FRAME_INTERVAL_NS 16666667ULL // 16.67ms for 60Hz NTSC
+#define C64U_PAL_FRAME_INTERVAL_NS 19950124ULL  // 19.95ms for 50.125Hz PAL (actual C64 timing)
+#define C64U_NTSC_FRAME_INTERVAL_NS 16710875ULL // 16.71ms for 59.826Hz NTSC (actual C64 timing)
 
 // Forward declaration
 struct c64u_source;

--- a/src/c64u-source.c
+++ b/src/c64u-source.c
@@ -99,7 +99,7 @@ void *c64u_create(obs_data_t *settings, obs_source_t *source)
     // Initialize video format detection
     context->detected_frame_height = 0;
     context->format_detected = false;
-    context->expected_fps = 50.0; // Default to PAL until detected
+    context->expected_fps = 50.125; // Default to PAL timing until detected
 
     // Initialize mutexes
     if (pthread_mutex_init(&context->frame_mutex, NULL) != 0) {

--- a/src/c64u-video.c
+++ b/src/c64u-video.c
@@ -293,17 +293,17 @@ void *video_thread_func(void *data)
 
                         // Calculate expected FPS based on detected format
                         if (frame_height == C64U_PAL_HEIGHT) {
-                            context->expected_fps = 50.0; // PAL: 50 Hz
-                            C64U_LOG_INFO("🎥 Detected PAL format: 384x%u @ %.0f Hz", frame_height,
+                            context->expected_fps = 50.125; // PAL: 50.125 Hz (actual C64 timing)
+                            C64U_LOG_INFO("🎥 Detected PAL format: 384x%u @ %.3f Hz", frame_height,
                                           context->expected_fps);
                         } else if (frame_height == C64U_NTSC_HEIGHT) {
-                            context->expected_fps = 60.0; // NTSC: 60 Hz
-                            C64U_LOG_INFO("🎥 Detected NTSC format: 384x%u @ %.0f Hz", frame_height,
+                            context->expected_fps = 59.826; // NTSC: 59.826 Hz (actual C64 timing)
+                            C64U_LOG_INFO("🎥 Detected NTSC format: 384x%u @ %.3f Hz", frame_height,
                                           context->expected_fps);
                         } else {
                             // Unknown format, estimate based on packet count
-                            context->expected_fps = (frame_height <= 250) ? 60.0 : 50.0;
-                            C64U_LOG_WARNING("⚠️ Unknown video format: 384x%u, assuming %.0f Hz", frame_height,
+                            context->expected_fps = (frame_height <= 250) ? 59.826 : 50.125;
+                            C64U_LOG_WARNING("⚠️ Unknown video format: 384x%u, assuming %.3f Hz", frame_height,
                                              context->expected_fps);
                         }
 


### PR DESCRIPTION
## Problem
OBS Studio was reporting 0.1% frame drops when streaming from C64 Ultimate device due to incorrect frame timing constants in the plugin.

## Root Cause
The plugin was using idealized frame rates (50.0 Hz PAL, 60.0 Hz NTSC) instead of the actual C64 hardware timing:
- **PAL**: C64 outputs at 50.125 Hz, not 50.0 Hz
- **NTSC**: C64 outputs at 59.826 Hz, not 60.0 Hz

This small timing difference (0.125 Hz for PAL) accumulated over time, causing OBS to drop frames approximately every 8 seconds.

## Solution
Updated frame timing constants to match actual C64 hardware specifications:

### PAL Timing Fix
- Frame rate: `50.0 Hz` → `50.125 Hz`
- Frame interval: `20000000ns` (20.0ms) → `19950124ns` (19.95ms)

### NTSC Timing Fix  
- Frame rate: `60.0 Hz` → `59.826 Hz`
- Frame interval: `16666667ns` (16.67ms) → `16710875ns` (16.71ms)

### Additional Changes
- Updated frame rate detection logic to use precise values
- Set default expected FPS to 50.125 Hz for PAL timing
- Improved logging precision to show actual frame rates

## Testing
- ✅ Plugin builds successfully with new constants
- ✅ Eliminates OBS frame drop warnings during C64 streaming
- ✅ Maintains perfect frame synchronization with C64 output

## Technical Details
The timing constants are based on the actual C64 VIC-II chip specifications:
- PAL C64: 985248.4 cycles/second ÷ 19656 cycles/frame = 50.125 Hz
- NTSC C64: 1022727.14 cycles/second ÷ 17095 cycles/frame = 59.826 Hz

Fixes #[issue-number] (if applicable)