### PR TITLE
Fix e2e tests in dockerized ubuntu build

### DIFF
--- a/.github/docker/Dockerfile.ubuntu-build
+++ b/.github/docker/Dockerfile.ubuntu-build
@@ -37,6 +37,13 @@ RUN apt-get install -y --no-install-recommends \
         file \
         dpkg-dev \
         xz-utils \
+        net-tools \
+        libgl1 \
+        libgl1-mesa-dri \
+        libglu1-mesa \
+        libxkbcommon-x11-0 \
+        libxcb-xinerama0 \
+        fonts-dejavu-core \
         libgles2-mesa-dev \
         libsimde-dev \
         obs-studio \

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -570,17 +570,17 @@ jobs:
 
             # Find the .so file and data directory
             so_file=$(find /tmp/plugin_extract -name "*.so" -type f | head -1)
-            data_dir=$(find /tmp/plugin_extract -name "data" -type d | head -1)
+            data_dir=$(find /tmp/plugin_extract -path "*/obs-plugins/c64stream" -type d | head -1)
 
             if [[ -n "$so_file" ]]; then
               echo "📦 Installing from TAR.XZ: $so_file"
               mkdir -p ~/.config/obs-studio/plugins/c64stream/bin/64bit
               cp "$so_file" ~/.config/obs-studio/plugins/c64stream/bin/64bit/
 
-              if [[ -n "$data_dir" ]]; then
-                mkdir -p ~/.config/obs-studio/plugins/c64stream/data
-                cp -r "$data_dir"/* ~/.config/obs-studio/plugins/c64stream/data/
-              fi
+            if [[ -n "$data_dir" ]]; then
+              mkdir -p ~/.config/obs-studio/plugins/c64stream/data
+              cp -r "$data_dir"/* ~/.config/obs-studio/plugins/c64stream/data/
+            fi
               echo "✅ Plugin installed via TAR.XZ extraction"
               exit 0
             fi
@@ -634,6 +634,9 @@ jobs:
 
           # Set up environment for headless operation
           export DISPLAY=:99
+          export QT_QPA_PLATFORM=xcb
+          export QT_X11_NO_MITSHM=1
+          export LIBGL_ALWAYS_SOFTWARE=1
           export PULSE_SERVER="unix:${XDG_RUNTIME_DIR}/pulse/native"
 
           # Clean up any stale processes and lock files
@@ -712,7 +715,8 @@ jobs:
             --frames "${{ inputs.e2e_frames }}" \
             --output-dir "../../e2e-results" \
             --skip-build \
-            --verbose
+            --verbose \
+            --display ":99"
 
       - name: Collect Test Artifacts 📋
         if: always()

--- a/tests/e2e/e2e.py
+++ b/tests/e2e/e2e.py
@@ -135,6 +135,10 @@ class E2ETest:
                     self.log(f"✅ Xvfb already running on {display} (started by workflow)")
                     # Set DISPLAY environment variable
                     os.environ['DISPLAY'] = display
+                    # Ensure Qt/GL behave in headless container
+                    os.environ.setdefault('QT_QPA_PLATFORM', 'xcb')
+                    os.environ.setdefault('QT_X11_NO_MITSHM', '1')
+                    os.environ.setdefault('LIBGL_ALWAYS_SOFTWARE', '1')
                     self.xvfb_process = None  # Not managed by us
                     return True
             except Exception:
@@ -167,6 +171,9 @@ class E2ETest:
 
             # Set DISPLAY environment variable
             os.environ['DISPLAY'] = display
+            os.environ.setdefault('QT_QPA_PLATFORM', 'xcb')
+            os.environ.setdefault('QT_X11_NO_MITSHM', '1')
+            os.environ.setdefault('LIBGL_ALWAYS_SOFTWARE', '1')
 
             # Give Xvfb time to start
             time.sleep(2)
@@ -641,11 +648,16 @@ DockAreaVisible=false
 
             self.log(f"Running: {' '.join(obs_cmd)}")
 
+            env_vars = dict(os.environ, DISPLAY=os.environ.get('DISPLAY', ':99'))
+            # Ensure predictable Qt platform in container
+            env_vars.setdefault('QT_QPA_PLATFORM', 'xcb')
+            env_vars.setdefault('QT_X11_NO_MITSHM', '1')
+            env_vars.setdefault('LIBGL_ALWAYS_SOFTWARE', '1')
             self.obs_process = subprocess.Popen(
                 obs_cmd,
                 stdout=subprocess.PIPE,
                 stderr=subprocess.PIPE,
-                env=dict(os.environ, DISPLAY=os.environ.get('DISPLAY', ':99'))
+                env=env_vars
             )
 
             # Give OBS time to initialize

--- a/tests/e2e/e2e.sh
+++ b/tests/e2e/e2e.sh
@@ -37,6 +37,7 @@ DEFAULT_VERBOSE=false
 DEFAULT_SKIP_BUILD=false
 DEFAULT_CLEANUP=true
 DEFAULT_OBS_ENABLED=true   # OBS integration now implemented
+DEFAULT_X11_DISPLAY=":99"
 DEFAULT_MONITOR_RESOURCES=false  # Resource monitoring for CI
 
 # Color output
@@ -266,6 +267,10 @@ parse_args() {
             --monitor-resources)
                 MONITOR_RESOURCES=true
                 shift
+                ;;
+            --display)
+                DEFAULT_X11_DISPLAY="$2"
+                shift 2
                 ;;
             -h|--help)
                 show_help
@@ -524,6 +529,12 @@ run_e2e_test() {
         "--audio-port" "${AUDIO_PORT}"
         "--udp-replay" "${BUILD_DIR}/tests/e2e/udp_replay"
     )
+
+    # Ensure X environment variables are set for Qt/OBS in CI
+    export DISPLAY="${DEFAULT_X11_DISPLAY}"
+    export QT_QPA_PLATFORM=xcb
+    export QT_X11_NO_MITSHM=1
+    export LIBGL_ALWAYS_SOFTWARE=1
 
     if [[ "${VERBOSE}" == true ]]; then
         cmd+=("--verbose")


### PR DESCRIPTION
Fix E2E tests in the dockerized Ubuntu build on CI by adding necessary X11/Qt/GL environment settings and Docker packages.

The E2E tests were failing on the GitHub Actions runner using the custom Docker image, despite working locally. This was due to subtle differences in the headless X11 environment, Qt rendering, OpenGL libraries, and network utilities available in the Docker container compared to a bare-metal Kubuntu desktop. These changes port robustness tweaks from the `feature/fix-e2e-on-ci` branch and ensure the CI environment provides the necessary dependencies and configurations for OBS and the plugin to render correctly.

---
<a href="https://cursor.com/background-agent?bcId=bc-379849b1-bd62-4c4c-bbc8-f61db424be0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-379849b1-bd62-4c4c-bbc8-f61db424be0a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

