### PR TITLE
Fix e2e build syntax error

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -739,7 +739,7 @@ jobs:
 
       - name: Run E2E Tests 🧪
         run: |
-          : Run E2E Tests 🧪 (Non-blocking - failures won't fail the build)
+          : "Run E2E Tests 🧪 (Non-blocking - failures won't fail the build)"
 
           cd tests/e2e
 


### PR DESCRIPTION
Quote the descriptive no-op line in `build-project.yaml` to fix a bash syntax error breaking the E2E CI build.

---
<a href="https://cursor.com/background-agent?bcId=bc-a0490910-e0aa-46dc-b597-396f5e0e60e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-a0490910-e0aa-46dc-b597-396f5e0e60e9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

