### PR TITLE
Fix Ubuntu release artifacts

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -358,6 +358,12 @@ jobs:
           submodules: recursive
           fetch-depth: 0
 
+      - name: Fetch Git Tags 🏷️
+        run: |
+          : Fetch Git Tags 🏷️
+          git config --global --add safe.directory "$(pwd)"
+          git fetch --force --tags
+
       - name: Set Up Environment 🔧
         id: setup
         run: |
@@ -396,10 +402,12 @@ jobs:
           cmake --build build_x86_64 --config ${{ needs.check-event.outputs.config }} --parallel
 
       - name: Package Plugin 📦
+        env:
+          PLUGIN_VERSION_OVERRIDE: ${{ needs.check-event.outputs.pluginVersion }}
         run: |
           : Package Plugin 📦
-          cd build_x86_64
-          cpack -G "TXZ;DEB;External" -C ${{ needs.check-event.outputs.config }}
+          cmake --build build_x86_64 --config ${{ needs.check-event.outputs.config }} -t package_source
+          cmake --build build_x86_64 --config ${{ needs.check-event.outputs.config }} -t package
 
       - name: Prepare Artifacts 📋
         run: |


### PR DESCRIPTION
## Summary
- fetch tags in the Docker-based Ubuntu build so CMake sees the release version tag
- call the CMake package_source and package targets to recreate the source tarball and correctly versioned Debian artifacts

## Testing
- not run (workflow change only)
