### PR TITLE
Fix Ubuntu CI build: replace deprecated obs_properties_add_button

### DIFF
--- a/.github/docker/Dockerfile.ubuntu-build
+++ b/.github/docker/Dockerfile.ubuntu-build
@@ -1,5 +1,17 @@
 # Pre-built Ubuntu container with OBS Studio and Qt6 dependencies
 # This dramatically speeds up CI builds by avoiding 3.5+ minute APT installations
+#
+# OBS Studio is installed from Ubuntu's own noble-backports pocket at a pinned version,
+# NOT from ppa:obsproject/obs-studio. The PPA only ever publishes the latest upstream
+# release with no retained history, so it silently drifts forward on every image
+# rebuild (this project's images auto-rebuild every 7 days). That drift previously broke
+# the build outright (a newer OBS Studio release deprecated an API this project used
+# with -Werror enabled) and separately broke E2E tests on Debian/Fedora, which pin an
+# older OBS Studio version for ABI compatibility with the plugin .so built in this image
+# (the same .so is copied into the Debian/Fedora/Arch containers for E2E testing without
+# recompiling). Pinning here to the same version Debian already pins keeps all three
+# ABI-compatible. If you deliberately bump this, update Dockerfile.debian-build's
+# OBS_VERSION to match.
 
 FROM ubuntu:24.04
 
@@ -11,18 +23,17 @@ LABEL org.opencontainers.image.licenses="GPL-2.0-or-later"
 # Prevent interactive prompts during package installation
 ENV DEBIAN_FRONTEND=noninteractive
 ENV TZ=UTC
+ENV OBS_STUDIO_VERSION=30.2.3+dfsg-3~bpo24.04.1
 
-# Install essential packages and add OBS Studio PPA
+# Install essential packages (noble-backports is already enabled by default in this
+# base image's /etc/apt/sources.list.d/ubuntu.sources, so no extra repo setup is needed)
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends \
-        software-properties-common \
         ca-certificates \
         curl \
         wget \
         gnupg \
-        lsb-release && \
-    add-apt-repository --yes ppa:obsproject/obs-studio && \
-    apt-get update -qq
+        lsb-release
 
 # Install build dependencies and OBS Studio (the time-consuming part)
 RUN apt-get install -y --no-install-recommends \
@@ -49,7 +60,6 @@ RUN apt-get install -y --no-install-recommends \
         libgles2-mesa-dev \
         libsimde-dev \
         libcurl4-openssl-dev \
-        obs-studio \
         qt6-base-dev \
         libqt6svg6-dev \
         qt6-base-private-dev \
@@ -75,6 +85,9 @@ RUN apt-get install -y --no-install-recommends \
         libasound2-dev \
         libpulse-dev \
         linux-tools-generic && \
+    apt-get install -y --no-install-recommends -t noble-backports \
+        "obs-studio=${OBS_STUDIO_VERSION}" \
+        "libobs-dev=${OBS_STUDIO_VERSION}" && \
     apt-get update -qq && apt-get install -y file && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/src/ui/c64-properties.c
+++ b/src/ui/c64-properties.c
@@ -2329,9 +2329,9 @@ obs_properties_t *c64_create_properties(void *data)
     obs_data_release(current_settings_for_playlist);
 
     // Refresh playlist button (directly below playlist dropdown)
-    obs_property_t *refresh_playlist_prop = obs_properties_add_button(rest_props, "automation_refresh_playlist",
-                                                                      obs_module_text("RefreshPlaylist"),
-                                                                      automation_refresh_playlist_clicked);
+    obs_property_t *refresh_playlist_prop = obs_properties_add_button2(rest_props, "automation_refresh_playlist",
+                                                                       obs_module_text("RefreshPlaylist"),
+                                                                       automation_refresh_playlist_clicked, data);
     obs_property_set_long_description(refresh_playlist_prop, obs_module_text("RefreshPlaylist.Description"));
 
     // Get automation status to determine button state
@@ -2347,8 +2347,8 @@ obs_properties_t *c64_create_properties(void *data)
     // Play/Stop Content button - label changes based on state
     const char *button_label = automation_running ? obs_module_text("AutomationStopContent")
                                                   : obs_module_text("AutomationPlayContent");
-    obs_property_t *auto_start_stop_prop =
-        obs_properties_add_button(rest_props, "automation_start_stop", button_label, automation_start_stop_clicked);
+    obs_property_t *auto_start_stop_prop = obs_properties_add_button2(rest_props, "automation_start_stop", button_label,
+                                                                      automation_start_stop_clicked, data);
     obs_property_set_long_description(auto_start_stop_prop, automation_running
                                                                 ? obs_module_text("AutomationStopContent.Description")
                                                                 : obs_module_text("AutomationPlayContent.Description"));
@@ -2359,18 +2359,18 @@ obs_properties_t *c64_create_properties(void *data)
     }
 
     // Next button (only enabled when playing)
-    obs_property_t *auto_next_prop = obs_properties_add_button(
-        rest_props, "automation_next", obs_module_text("AutomationNext"), automation_next_clicked);
+    obs_property_t *auto_next_prop = obs_properties_add_button2(
+        rest_props, "automation_next", obs_module_text("AutomationNext"), automation_next_clicked, data);
     obs_property_set_long_description(auto_next_prop, obs_module_text("AutomationNext.Description"));
     obs_property_set_enabled(auto_next_prop, automation_running);
 
     // Reset controls (split into two buttons)
-    obs_property_t *reset_plugin_prop =
-        obs_properties_add_button(rest_props, "reset_plugin", obs_module_text("ResetPlugin"), reset_plugin_clicked);
+    obs_property_t *reset_plugin_prop = obs_properties_add_button2(
+        rest_props, "reset_plugin", obs_module_text("ResetPlugin"), reset_plugin_clicked, data);
     obs_property_set_long_description(reset_plugin_prop, obs_module_text("ResetPlugin.Description"));
 
     obs_property_t *reset_c64u_prop =
-        obs_properties_add_button(rest_props, "reset_c64u", obs_module_text("ResetC64U"), reset_c64u_clicked);
+        obs_properties_add_button2(rest_props, "reset_c64u", obs_module_text("ResetC64U"), reset_c64u_clicked, data);
     obs_property_set_long_description(reset_c64u_prop, obs_module_text("ResetC64U.Description"));
 
     // Script Group
@@ -2450,8 +2450,8 @@ obs_properties_t *c64_create_properties(void *data)
     // Start/Stop button - label changes based on state
     const char *script_button_label = is_running_or_paused ? obs_module_text("ScriptStopScript")
                                                            : obs_module_text("ScriptStartScript");
-    obs_property_t *script_start_stop_prop =
-        obs_properties_add_button(script_props, "script_start_stop", script_button_label, script_start_stop_clicked);
+    obs_property_t *script_start_stop_prop = obs_properties_add_button2(
+        script_props, "script_start_stop", script_button_label, script_start_stop_clicked, data);
     obs_property_set_long_description(script_start_stop_prop, is_running_or_paused
                                                                   ? obs_module_text("ScriptStartStop.Stop")
                                                                   : obs_module_text("ScriptStartStop.Start"));
@@ -2470,19 +2470,19 @@ obs_properties_t *c64_create_properties(void *data)
         debug_desc = obs_module_text("ScriptDebugScript.Description");
     }
     obs_property_t *script_pause_resume_prop =
-        obs_properties_add_button(script_props, "script_pause_resume", debug_label, script_pause_resume_clicked);
+        obs_properties_add_button2(script_props, "script_pause_resume", debug_label, script_pause_resume_clicked, data);
     obs_property_set_long_description(script_pause_resume_prop, debug_desc);
     obs_property_set_enabled(script_pause_resume_prop, context->script_file_path[0] != '\0');
 
     // Step button - only enabled when paused
-    obs_property_t *script_step_prop =
-        obs_properties_add_button(script_props, "script_step", obs_module_text("ScriptStep"), script_step_clicked);
+    obs_property_t *script_step_prop = obs_properties_add_button2(
+        script_props, "script_step", obs_module_text("ScriptStep"), script_step_clicked, data);
     obs_property_set_long_description(script_step_prop, obs_module_text("ScriptStep.Description"));
     obs_property_set_enabled(script_step_prop, current_status == C64_SCRIPT_STATUS_PAUSED);
 
     // Log variables button
-    obs_property_t *script_log_vars_prop = obs_properties_add_button(
-        script_props, "script_log_vars", obs_module_text("ScriptLogVariables"), script_log_variables_clicked);
+    obs_property_t *script_log_vars_prop = obs_properties_add_button2(
+        script_props, "script_log_vars", obs_module_text("ScriptLogVariables"), script_log_variables_clicked, data);
     obs_property_set_long_description(script_log_vars_prop, obs_module_text("ScriptLogVariables.Description"));
     obs_property_set_enabled(script_log_vars_prop, is_running_or_paused);
 


### PR DESCRIPTION
## Summary

The Ubuntu CI job started failing on `main` (run [31306423689](https://github.com/chrisgleissner/c64stream/actions/runs/31306423689)) with:

```
error: 'obs_properties_add_button' is deprecated [-Werror=deprecated-declarations]
```

No source change caused this. `.github/workflows/build-project.yaml` rebuilds the Ubuntu Docker image every 7 days for freshness even without Dockerfile changes, and `.github/docker/Dockerfile.ubuntu-build` installs `obs-studio` unpinned from `ppa:obsproject/obs-studio`. The scheduled rebuild picked up a newer libobs release that newly marks `obs_properties_add_button` as deprecated. This project compiles with `-Werror -Wdeprecated-declarations`, so the previously passing code failed to build once the image refreshed.

PR #126 already migrated four button call sites (device discovery, save, delete) to `obs_properties_add_button2`, which takes an explicit `void *priv` argument instead of relying on a separate mechanism. This PR converts the eight remaining call sites in `c64_create_properties()` the same way, passing the existing `data` parameter as `priv`. No behavior change — `obs_properties_add_button2` has the same callback signature (`obs_property_clicked_t`), so `data`/`priv` was already accessible inside the click handlers before this change.

## Test plan

- [x] Local build via `ninja c64stream` in `build_x86_64` succeeds with no warnings from this file
- [x] `clang-format -n --Werror src/ui/c64-properties.c` passes
- [ ] CI Ubuntu Build job goes green