### PR TITLE
Resolve latest OBS Studio release dynamically for smoke tests

### DIFF
--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -139,6 +139,7 @@ jobs:
     outputs:
       versions_json: ${{ steps.resolve.outputs.versions_json }}
     steps:
+      - uses: actions/checkout@v4
       - name: Resolve Latest OBS Studio Release 🔎
         id: resolve
         env:
@@ -155,11 +156,19 @@ jobs:
           fi
           echo "🔍 Latest stable OBS Studio release: ${latest_version}"
 
-          # Kept in sync with buildspec.json's obs-studio dependency version -
-          # this is the SDK version the plugin is actually compiled against.
-          build_version="32.0.4"
+          # Read from buildspec.json rather than hardcoding, so this can't itself
+          # go stale relative to the SDK version the plugin is actually built
+          # against (the same class of bug this job exists to fix).
+          build_version="$(jq -r '.dependencies."obs-studio".version' buildspec.json)"
+          if [[ -z "${build_version}" || "${build_version}" == "null" ]]; then
+            echo "::error::Failed to read obs-studio dependency version from buildspec.json"
+            exit 1
+          fi
+          echo "🔧 Build SDK OBS Studio version: ${build_version}"
 
-          if [[ "${latest_version}" == "${build_version}" ]]; then
+          # Normalize away a possible "v" tag prefix before comparing, so this
+          # still dedupes correctly if either side's version format changes.
+          if [[ "${latest_version#v}" == "${build_version#v}" ]]; then
             versions_json="[\"${build_version}\"]"
           else
             versions_json="[\"${build_version}\", \"${latest_version}\"]"

--- a/.github/workflows/build-project.yaml
+++ b/.github/workflows/build-project.yaml
@@ -133,6 +133,40 @@ jobs:
           fi
           echo "pluginVersion=${plugin_version}" >> $GITHUB_OUTPUT
 
+  resolve-obs-versions:
+    name: Resolve OBS Smoke Test Versions 🔎
+    runs-on: ubuntu-24.04
+    outputs:
+      versions_json: ${{ steps.resolve.outputs.versions_json }}
+    steps:
+      - name: Resolve Latest OBS Studio Release 🔎
+        id: resolve
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          : Resolve Latest OBS Studio Release 🔎
+
+          # GitHub's /releases/latest endpoint already excludes drafts and
+          # pre-releases (beta/rc), returning the newest stable tag.
+          latest_version="$(gh api repos/obsproject/obs-studio/releases/latest --jq '.tag_name')"
+          if [[ -z "${latest_version}" ]]; then
+            echo "::error::Failed to resolve latest OBS Studio release from GitHub API"
+            exit 1
+          fi
+          echo "🔍 Latest stable OBS Studio release: ${latest_version}"
+
+          # Kept in sync with buildspec.json's obs-studio dependency version -
+          # this is the SDK version the plugin is actually compiled against.
+          build_version="32.0.4"
+
+          if [[ "${latest_version}" == "${build_version}" ]]; then
+            versions_json="[\"${build_version}\"]"
+          else
+            versions_json="[\"${build_version}\", \"${latest_version}\"]"
+          fi
+          echo "🧪 Smoke test versions: ${versions_json}"
+          echo "versions_json=${versions_json}" >> "$GITHUB_OUTPUT"
+
   macos-build:
     name: Build for macOS 🍏
     runs-on: macos-15
@@ -659,13 +693,14 @@ jobs:
   macos-smoke-test:
     name: macOS Smoke Test (OBS ${{ matrix.obs-version }}) 💨
     uses: ./.github/workflows/macos-smoke-test.yaml
-    needs: [macos-build]
+    needs: [macos-build, resolve-obs-versions]
     strategy:
       fail-fast: false
       matrix:
-        # Validate against the OBS version we build against (buildspec.json) and
-        # the latest stable release
-        obs-version: ["32.0.4", "32.1.2"]
+        # Validates against the OBS version we build against (buildspec.json) and
+        # the latest stable release, resolved dynamically by resolve-obs-versions
+        # so this never goes stale as new OBS Studio versions ship.
+        obs-version: ${{ fromJSON(needs.resolve-obs-versions.outputs.versions_json) }}
     with:
       artifact-pattern: "*-macos-universal-*"
       obs-version: ${{ matrix.obs-version }}
@@ -673,11 +708,11 @@ jobs:
   windows-x64-smoke-test:
     name: Windows x64 Smoke Test (OBS ${{ matrix.obs-version }}) 💨
     uses: ./.github/workflows/windows-smoke-test.yaml
-    needs: [windows-build]
+    needs: [windows-build, resolve-obs-versions]
     strategy:
       fail-fast: false
       matrix:
-        obs-version: ["32.0.4", "32.1.2"]
+        obs-version: ${{ fromJSON(needs.resolve-obs-versions.outputs.versions_json) }}
     with:
       arch: x64
       artifact-pattern: "*-windows-x64-*"
@@ -687,11 +722,11 @@ jobs:
   windows-arm64-smoke-test:
     name: Windows ARM64 Smoke Test (OBS ${{ matrix.obs-version }}) 💨
     uses: ./.github/workflows/windows-smoke-test.yaml
-    needs: [windows-arm64-build]
+    needs: [windows-arm64-build, resolve-obs-versions]
     strategy:
       fail-fast: false
       matrix:
-        obs-version: ["32.0.4", "32.1.2"]
+        obs-version: ${{ fromJSON(needs.resolve-obs-versions.outputs.versions_json) }}
     with:
       arch: arm64
       artifact-pattern: "*-windows-arm64-*"


### PR DESCRIPTION
## Summary

The Windows and macOS smoke-test jobs in `build-project.yaml` validated the plugin against two hardcoded OBS Studio versions: `32.0.4` (the SDK version pinned in `buildspec.json`) and `32.1.2`, with a comment stating the second entry represents "the latest stable release". That value never updates itself. OBS Studio has since shipped `32.2.0` and `32.2.1`, so the "latest" smoke test has silently been running two releases behind actual latest, with nothing in CI flagging that it had gone stale.

This follows up on #128, during which we found the same class of problem (a version pinned once and never revisited) causing E2E failures elsewhere in this pipeline.

## Change

Adds a `resolve-obs-versions` job that queries `GET /repos/obsproject/obs-studio/releases/latest` (which GitHub already filters to exclude drafts and pre-releases) once per workflow run, and outputs a JSON array combining the fixed build-SDK version (`32.0.4`, matching `buildspec.json`) with whatever the actual current latest stable release is. If they happen to match, the array is deduplicated to avoid running the same version twice.

The three smoke-test jobs (`macos-smoke-test`, `windows-x64-smoke-test`, `windows-arm64-smoke-test`) now source their `obs-version` matrix from `fromJSON(needs.resolve-obs-versions.outputs.versions_json)` instead of a hardcoded array.

Linux is not affected by this change — Linux has no equivalent smoke test against a real official OBS binary; that's a separate gap, not addressed here.

## Test plan

- [x] `python3 -c "import yaml; yaml.safe_load(...)"` — YAML parses
- [x] `build-aux/validate-workflows` — passes for all 8 workflow files, including Actions-schema validation
- [x] Ran the version-resolution logic locally against the live GitHub API: resolves to `32.2.1` (current actual latest), producing `["32.0.4", "32.2.1"]`, which parses as valid JSON
- [ ] CI run on this PR will exercise the real dynamic matrix end to end (workflow_call `fromJSON` matrix pattern is standard GitHub Actions behavior, but this is the first use of it in this repo)