### PR TITLE
Fix gersemi CI check: run brew update before installing formulae

### DIFF
--- a/.github/actions/run-gersemi/action.yaml
+++ b/.github/actions/run-gersemi/action.yaml
@@ -35,6 +35,14 @@ runs:
         echo ::group::Install Dependencies
         eval "$(/home/linuxbrew/.linuxbrew/bin/brew shellenv)"
         echo "/home/linuxbrew/.linuxbrew/bin:/home/linuxbrew/.linuxbrew/sbin" >> $GITHUB_PATH
+        # GitHub-hosted runners set HOMEBREW_NO_AUTO_UPDATE, so the preinstalled
+        # Homebrew core (install_steps.rb etc.) can fall behind the live bottle
+        # index it pulls formulae from. That skew has caused installs to fail
+        # with "unknown install step: run" when a formula's bottle uses a
+        # post-install step type the stale core code doesn't recognize yet.
+        # Explicitly updating first keeps Homebrew's own code in sync with what
+        # it is about to install.
+        brew update --quiet
         brew install --quiet zsh
         echo ::endgroup::
 


### PR DESCRIPTION
## Summary

The \`gersemi\` formatting check job started failing consistently on the \`1.2.0-rc2\` tag push (reproduced identically on two separate runs today, not a one-off flake):

\`\`\`
Error: unknown install step: run
.../install_steps.rb:570:in 'run_install_step'
\`\`\`

## Root cause

GitHub-hosted runners set \`HOMEBREW_NO_AUTO_UPDATE\`, so the Homebrew core code preinstalled on the runner image (\`/home/linuxbrew/.linuxbrew\`) never refreshes itself between runs. \`gersemi\`'s \`ca-certificates\` dependency's bottle started using a newer post-install step type that the stale core Ruby code on the runner doesn't know how to parse, so installation fails outright. Homebrew's own error output names the fix directly: "Do not report this issue until you've run \`brew update\` and tried again."

This did not block the \`1.2.0-rc2\` release - \`create-release\` in \`push.yaml\` only depends on \`build-project\`, not \`check-format\`, so the release was created successfully with all expected artifacts despite this failure. It only made the overall workflow run show red for an unrelated reason.

## Change

Adds \`brew update --quiet\` before the formula installs in \`run-gersemi/action.yaml\`, so Homebrew's own code stays in sync with whatever bottle format the live formula index is currently serving.

## Test plan

- [x] YAML syntax validated locally
- [ ] CI run on this PR exercises the fix directly (this file only has a real effect when \`.cmake\`/\`CMakeLists.txt\` files changed in the diff — need to confirm the gersemi step still runs/passes here, or verify against the next tag/main push that does touch CMake files)